### PR TITLE
Return $el when enableSearch is false

### DIFF
--- a/src/js/plugins/search/plugin.search.js
+++ b/src/js/plugins/search/plugin.search.js
@@ -76,7 +76,7 @@ BookReader.prototype.init = (function (super_) {
 BookReader.prototype.buildMobileDrawerElement = (function (super_) {
   return function () {
     const $el = super_.call(this);
-    if (!this.enableSearch) { return; }
+    if (!this.enableSearch) { return $el; }
     if (this.searchView.dom.mobileSearch) {
       $el.find('.BRmobileMenu__moreInfoRow').after(this.searchView.dom.mobileSearch);
     }
@@ -88,7 +88,7 @@ BookReader.prototype.buildMobileDrawerElement = (function (super_) {
 BookReader.prototype.buildToolbarElement = (function (super_) {
   return function () {
     const $el = super_.call(this);
-    if (!this.enableSearch) { return; }
+    if (!this.enableSearch) { return $el; }
     if (this.searchView.dom.toolbarSearch) {
       $el.find('.BRtoolbarSectionInfo').after(this.searchView.dom.toolbarSearch);
     }


### PR DESCRIPTION
If enableSearch is false, buildMobileDrawerElement doesn't return the element so it is very complicated to alter, I think it should return $el so it can be extended.

This is a preview PR to see the change I want to make, I think the tool needs to be compiled as well